### PR TITLE
Adjusted to make it runable as an unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,19 @@ Start the service with `start nfs_automount`.  Note that the log will be written
 
 Also note that whenever you modify the configuration file at /etc/nfs_automount.conf, you'll need to issue `service nfs_automount restart` in order for the changes to become effective.
 
+Running As Unprivileged User
+------------------------------------------
+
+By default, nfs_automount will run as root. However there might be circumstances which require to run nfs_automount as unprivileged user.
+
+For example when the security settings on the NFS shares prevent the root user to write to the share. In such instance, nfs_automount will declare the share as stale and thus will unmount and remount the share at the interval specified. A typcial use case would be a user share in a corporate environment where each user has its own share.
+
+To run nfs_automount as unprivileged user;
+
+    sudo su
+    nano /etc/init/nfs_automount.conf
+
+Make modifications according to the provided comments. 
 
 Version History
 ---------------

--- a/etc/init/nfs_automount.conf
+++ b/etc/init/nfs_automount.conf
@@ -5,7 +5,11 @@ description     "Automatically mount, unmount, and remount NFS shares."
 start on (local-filesystems and net-device-up IFACE!=lo)
 respawn
 
+# Runs nfs_automount as root. Comment this line out if you enabled nfs_automount to run as the unprivileged user below.
 exec /usr/local/bin/nfs_automount
+
+# Runs nfs_automount as the unprivileged user specified. Uncomment and replace "<MyUserName>" with the actual user name.
+# exec start-stop-daemon --start -u <MyUserName> --exec /usr/local/bin/nfs_automount
 
 pre-start script
   echo


### PR DESCRIPTION
In my use case, the NFS shares are not provisioned to give the root sufficient write access. Therefore nfs_automount declared the shares as stale every time it check on them. This caused them to be automatically unmounted and then remounted at the specified interval of 60 seconds.

Resolved this problem with the changes provided with this pull request.
