### PR TITLE
Enable mounting subdirectories

### DIFF
--- a/nfs_automount
+++ b/nfs_automount
@@ -221,7 +221,9 @@ function check_remoteshare {
     exit 1
   fi
 
-  remotesharecheck=`${showmountcmd} -e ${_remotesystem} | ${awkcmd} '{print $1}' | ${grepcmd} "${_remoteshare}"`
+  _remotesharebase="${_remoteshare#/}"
+  _remotesharebase="/${_remotesharebase%%/*}"
+  remotesharecheck=`${showmountcmd} -e ${_remotesystem} | ${awkcmd} '{print $1}' | ${grepcmd} "${_remotesharebase}"`
   if [ "${remotesharecheck}" != "" ] ; then
     _RET=true
   else


### PR DESCRIPTION
My nfs server shares "/nfs", but I like to mount "/nfs/Public".  This changes the check_remoteshare function to check for the base folder being shared instead of the full path.

I chose a pure bash method to get the base folder (no reliance on awk/cut/etc) found here:
http://stackoverflow.com/questions/24631866/how-to-get-root-directory-of-given-path-in-bash
