### PR TITLE
Added in compatibility for NFSv4 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 nfs_automount 
 =============
 
-Version 1.1 (2013-07-26)
+Version 1.1.1 (2022-02-14)
+
+Edits/changes for 1.1.1
+
+* Version 1.1 and below used an RPC check via the `showmount` command to check available remote host mountpoints, which works great with NFSv2 and NFSv3. This does *NOT* work with NFSv4 (see [this article](https://www.golinuxcloud.com/show-nfs-shares-list-nfs-client-mount-points/#Show_NFS_shares_on_NFS_Server)), so if an RPC error is detected, it now presumes that NFSv4 is being used and attempts the mount anyway if the server exists. If mounting does not occur (e.g. "backgrounding" due to a misconfiguration) it immediately unmounts the mountpoint instead of leaving it in the "backgrounded" state. No configuration changes are needed.
 
 The goal of this script is to provide static (i.e. /etc/fstab-like) NFS mounts, while at the same time supporting cross-mounts between servers.  
 
@@ -23,10 +27,9 @@ nfs_automount offers a solution:
 
 * Written in bash script with modular and clear syntax.  
 
-* Tested on Ubuntu 12.x (should also work on Debian) and CentOS 6.x (should also work on RedHat).  
+* Tested on Ubuntu 12.x (also tested on Debian Bullseye as a cronjob) and CentOS 6.x (should also work on RedHat).  
 
 * Distributed under MIT license.
-
 
 This complete rewrite of nfs_automount is based on older versions I wrote ([July 2010](http://my.galagzee.com/2010/07/23/mounting-nfs-share-after-boot-and-checking-up-on-it-periodically/), [May 2011](http://my.galagzee.com/2011/05/26/nfs-automount-linux-version/), and [December 2011](http://my.galagzee.com/2011/12/19/nfs-enforcer/)).  When I started making further changes to the script in July 2013 I was unhappy with the original script's deeply nested structure which made it problmatic to extend it as I wanted.  I also came across [AutoNFS](https://help.ubuntu.com/community/AutomaticallyMountNFSSharesWithoutAutofsHowto) script on Ubuntu's Community Wiki which gave me further ideas and inspiration. 
 

--- a/nfs_automount
+++ b/nfs_automount
@@ -4,6 +4,11 @@
 # Copyright (c) 2013 Ville Walveranta 
 # http://my.galagzee.com
 
+# Edited by Steven Saus (c) 2022
+# Noting that NFS4 does not use the RPC function, so that test always fails.
+# Added a small check that if RPC returns an error, it will attempt to mount
+# the configured NFS drive anyway.
+
 # Absolute path to the configuration file 
 # (if empty or not defined, the default is
 # 'nfs_automount.conf' in the script's directory)
@@ -71,7 +76,7 @@ function log {
       if [ -f ${LOGFILEPATH} ] ; then
         _output_type="log"
       else
-      	 touch ${LOGFILEPATH} > /dev/null 2>&1
+         touch ${LOGFILEPATH} > /dev/null 2>&1
          if [ -f ${LOGFILEPATH} ] ; then
            _output_type="log"
          fi
@@ -222,10 +227,17 @@ function check_remoteshare {
   fi
 
   remotesharecheck=`${showmountcmd} -e ${_remotesystem} | ${awkcmd} '{print $1}' | ${grepcmd} "${_remoteshare}"`
-  if [ "${remotesharecheck}" != "" ] ; then
-    _RET=true
-  else
-    _RET=false
+
+    if [ "${remotesharecheck}" != "" ] ; then
+        _RET=true
+    else
+        remotesharecheck=`${showmountcmd} -e ${_remotesystem} | ${awkcmd} '{print $1}' | ${grepcmd} "rpc" 2>&1`
+        if [ "${remotesharecheck}" != "" ] ; then
+            _RET=false
+        else
+            log "[INFO] RPC not enabled; assuming this is an NFS4 mount"
+            _RET=true
+        fi
   fi
 }
 
@@ -307,7 +319,7 @@ function nfs_mount {
     # Make sure the remote NFS share is available
     check_remoteshare ${_remotesystem} ${_remoteshare}
     if ${_RET} ; then
-
+    
       # Make sure the local mountpoint exists and is free
       valid_for_mount ${_localmountpoint}
       if ${_RET} ; then
@@ -369,7 +381,7 @@ while : ; do
 
     get_mount_dataset ${MOUNTDATA[$i]}
 
-	((datasetno=${i} + 1))
+    ((datasetno=${i} + 1))
 
     if [ ${#_RET[@]} -lt 5 ] ; then
       log "[CRIT] Incomplete mount dataset ${datasetno} in '${CONFIG}'. Skipping!"


### PR DESCRIPTION
* Version 1.1 and below used an RPC check via the `showmount` command to check available remote host mountpoints, which works great with NFSv2 and NFSv3. This does *NOT* work with NFSv4 (see [this article](https://www.golinuxcloud.com/show-nfs-shares-list-nfs-client-mount-points/#Show_NFS_shares_on_NFS_Server)), so if an RPC error is detected, it now presumes that NFSv4 is being used and attempts the mount anyway if the server exists. If mounting does not occur (e.g. "backgrounding" due to a misconfiguration) it immediately unmounts the mountpoint instead of leaving it in the "backgrounded" state. No configuration changes are needed.
